### PR TITLE
Add support for HA versions older than latest (2026.8)

### DIFF
--- a/custom_components/planta/__init__.py
+++ b/custom_components/planta/__init__.py
@@ -51,7 +51,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: PlantaConfigEntry) -> bo
     except ConfigEntryAuthFailed:
         raise
     except Exception:
-        _LOGGER.exception()
+        msg = "Unexpected error setting up Planta entry"
+        _LOGGER.exception(msg)
 
     if not coordinator.data:
         raise ConfigEntryNotReady

--- a/custom_components/planta/coordinator.py
+++ b/custom_components/planta/coordinator.py
@@ -87,9 +87,15 @@ class PlantaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         ):
             device_registry = dr.async_get(self.hass)
             for device_id in stale_plants:
-                device = device_registry.async_get_device_by_identifier(
-                    (DOMAIN, device_id), self.config_entry.entry_id
-                )
+                # Home Assistant >= 2026.8
+                if hasattr(device_registry, "async_get_device_by_identifier"):
+                    device = device_registry.async_get_device_by_identifier(
+                        (DOMAIN, device_id), self.config_entry.entry_id
+                    )
+                else:
+                    device = device_registry.async_get_device(
+                        identifiers={(DOMAIN, device_id)}
+                    )
                 if device:
                     device_registry.async_remove_device(device.id)
         self.previous_plants = current_plants


### PR DESCRIPTION
1.2.0 introduced a breaking change for clients on HA older than 2026.8 without disclosing a minimum version to HACS. Given the support to include the previous method and the latest isn't a super heavy lift, figured this would be worth maintaining for some time until the maintainer(s) wish to drop support.

Additionally this fixes a minor yet critical bug when handling the entry's general exception catch path that fails to log any error, and causes the integration to crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup error logging with a clearer diagnostic message.
  * Enhanced compatibility across Home Assistant versions when identifying stale devices.
  * Preserved existing stale-device removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->