### PR TITLE
fix: Add missing exception log message

### DIFF
--- a/custom_components/planta/__init__.py
+++ b/custom_components/planta/__init__.py
@@ -51,7 +51,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: PlantaConfigEntry) -> bo
     except ConfigEntryAuthFailed:
         raise
     except Exception:
-        _LOGGER.exception()
+        msg = "Unexpected error setting up Planta entry"
+        _LOGGER.exception(msg)
 
     if not coordinator.data:
         raise ConfigEntryNotReady


### PR DESCRIPTION
I believe this bug discovered in #53 is what was causing total integration failure to startup. My reproduction steps were to use an unsupported version of HA to generate an exception to bubble up to that level.